### PR TITLE
Allow passing already open streams to process_create/3

### DIFF
--- a/process.c
+++ b/process.c
@@ -395,7 +395,6 @@ get_stream(term_t t, p_options *info, p_stream *stream)
     IOSTREAM *s = NULL;
     if ( !PL_get_stream_handle(stream->term, &s) )
       return PL_type_error("stream", stream->term);
-    /* stream->type = std_stream; */
     stream->type = std_stream;
     int fd = Sfileno(s);
     if ( fd > 0 )

--- a/process.c
+++ b/process.c
@@ -1147,6 +1147,7 @@ do_create_process(p_options *info)
 				      /* stdin */
   switch( info->streams[0].type )
   { case std_pipe:
+    case std_stream:
       si.hStdInput = info->streams[0].fd[0];
       SetHandleInformation(info->streams[0].fd[1],
 			   HANDLE_FLAG_INHERIT, FALSE);
@@ -1161,6 +1162,7 @@ do_create_process(p_options *info)
 				      /* stdout */
   switch( info->streams[1].type )
   { case std_pipe:
+    case std_stream:
       si.hStdOutput = info->streams[1].fd[1];
       SetHandleInformation(info->streams[1].fd[0],
 			   HANDLE_FLAG_INHERIT, FALSE);
@@ -1175,6 +1177,7 @@ do_create_process(p_options *info)
 				      /* stderr */
   switch( info->streams[2].type )
   { case std_pipe:
+    case std_stream:
       si.hStdError = info->streams[2].fd[1];
       SetHandleInformation(info->streams[2].fd[0],
                            HANDLE_FLAG_INHERIT, FALSE);

--- a/process.c
+++ b/process.c
@@ -390,14 +390,14 @@ get_stream(term_t t, p_options *info, p_stream *stream)
     info->pipes++;
     return TRUE;
   } else if ( PL_is_functor(t, FUNCTOR_stream1) )
-  { stream->term = PL_new_term_ref();
+  { IOSTREAM *s;
+    int fd;
+    stream->term = PL_new_term_ref();
     _PL_get_arg(1, t, stream->term);
-    IOSTREAM *s = NULL;
     if ( !PL_get_stream_handle(stream->term, &s) )
       return PL_type_error("stream", stream->term);
     stream->type = std_stream;
-    int fd = Sfileno(s);
-    if ( fd > 0 )
+    if ( (fd = Sfileno(s)) > 0 )
     { stream->fd[0] = stream->fd[1] = fd;
     } else
     { return PL_domain_error("Not valid file stream", stream->term);

--- a/process.c
+++ b/process.c
@@ -1779,7 +1779,7 @@ do_create_process(p_options *info)
 	posix_spawn_file_actions_addclose(&file_actions, info->streams[1].fd[0]);
       break;
     case std_stream:
-      posix_spawn_file_actions_adddup2(&file_actions, info->streams[1].fd[1], 0);
+      posix_spawn_file_actions_adddup2(&file_actions, info->streams[1].fd[1], 1);
       break;
     case std_null:
       posix_spawn_file_actions_addopen(&file_actions, 1,

--- a/process.c
+++ b/process.c
@@ -1057,7 +1057,7 @@ create_pipes(p_options *info)
   for(i=0; i<3; i++)
   { p_stream *s = &info->streams[i];
 
-    if ( s->term )
+    if ( s->term && s->type == std_pipe )
     { if ( i == 2 && info->streams[1].term &&
 	   PL_compare(info->streams[1].term, info->streams[2].term) == 0 )
       { s->fd[0] = info->streams[1].fd[0];

--- a/process.pl
+++ b/process.pl
@@ -148,6 +148,8 @@ following finds the executable for =ls=:
 %           returns end-of-file, writing produces no output
 %           * pipe(-Stream)
 %           Attach input and/or output to a Prolog stream.
+%           * stream(+Stream)
+%           Attach input or output to an existing file stream.
 %
 %       * cwd(+Directory)
 %       Run the new process in Directory.  Directory can be a


### PR DESCRIPTION
This allows the terms in the `stdin`/`stdout`/`stderr` options to also be `stream(SomeOpenStream)`, which if `SomeOpenStream` is a file stream, attaches that file to the relevant in/out/err of the created process.