### PR TITLE
Force Windows sockets to default to a send buffer of at least 64k. Pr…

### DIFF
--- a/nonblockio.h
+++ b/nonblockio.h
@@ -97,7 +97,8 @@ typedef enum				/* nbio_setopt() commands */
   TCP_OUTSTREAM,
   UDP_BROADCAST,
   SCK_BINDTODEVICE,
-  NBIO_END
+  NBIO_END,
+  TCP_SNDBUF
 } nbio_option;
 
 typedef enum

--- a/socket.c
+++ b/socket.c
@@ -94,6 +94,7 @@ static atom_t ATOM_max_message_size;    /* "message_size" */
 static atom_t ATOM_file_no;		/* "file_no" */
 static atom_t ATOM_ip_add_membership;	/* "ip_add_membership" */
 static atom_t ATOM_ip_drop_membership;	/* "ip_drop_membership" */
+static atom_t ATOM_sndbuf;	        /* "sndbuf" */
 static functor_t FUNCTOR_socket1;	/* $socket(Id) */
 
 static int get_socket_from_stream(term_t t, IOSTREAM **s, nbio_sock_t *sp);
@@ -346,6 +347,19 @@ pl_setopt(term_t Socket, term_t opt)
       else
 	return TRUE;
 #endif
+    } else if ( a == ATOM_sndbuf && arity == 1 )
+    { int bufsize;
+      int rc;
+      term_t a = PL_new_term_ref();
+      _PL_get_arg(1, opt, a);
+      if ( !PL_get_integer(a, &bufsize) )
+	return pl_error(NULL, 0, NULL, ERR_DOMAIN, a, "integer");
+      if ( (rc=nbio_setopt(socket, TCP_SNDBUF, bufsize) == 0) )
+	return TRUE;
+      if ( rc == -2 )
+	goto not_implemented;
+
+      return FALSE;
     }
   }
 
@@ -684,6 +698,7 @@ install_socket(void)
   ATOM_file_no		  = PL_new_atom("file_no");
   ATOM_ip_add_membership  = PL_new_atom("ip_add_membership");
   ATOM_ip_drop_membership = PL_new_atom("ip_drop_membership");
+  ATOM_sndbuf             = PL_new_atom("sndbuf");
 
   FUNCTOR_socket1 = PL_new_functor(PL_new_atom("$socket"), 1);
 

--- a/socket.pl
+++ b/socket.pl
@@ -546,6 +546,14 @@ try_proxy(socks(Host, Port), Address, Socket, StreamPair) :-
 %     dispatched on behalf of the user interface. Default is
 %     =true=. Only very specific situations require setting
 %     this to =false=.
+%
+%     - sndbuf(+Integer)
+%     Sets the send buffer size to Integer (bytes). On Windows this defaults
+%     (now) to 64kb. Higher latency links may benefit from increasing this
+%     further since the maximum theoretical throughput on a link is given by
+%     buffer-size / latency.
+%     See https://support.microsoft.com/en-gb/help/823764/slow-performance-occurs-when-you-copy-data-to-a-tcp-server-by-using-a
+%     for Microsoft's discussion
 
 %!  tcp_fcntl(+Stream, +Action, ?Argument) is det.
 %


### PR DESCRIPTION
…ovide an option (sndbuf/1) to tcp_setopt/1 to allow configuring it manually to another value.

On Windows 7, the default buffer size is 8kb (On Windows 8 and later, it's 64kb).

If the client and server have high latency (say, 300ms) then an 8kb buffer effectively limits non-blocking sockets to 8kb/0.3s = 26kb/s because of the way Windows implements send() (it'll return WSAEWOULDBLOCK until we get an ACK for the data in the buffer). 

In my testing, this means that transferring a 3MB file from Windows->Unix took over 20x as long as transferring the same data in the opposite direction over a symmetric connection.

Other projects have found this as well - see https://community.openvpn.net/openvpn/ticket/640
Also see Microsoft admitting that the problem exists at https://support.microsoft.com/en-gb/help/823764/slow-performance-occurs-when-you-copy-data-to-a-tcp-server-by-using-a

This PR increases the buffer to at least 64k on all versions of windows, and adds a new option to tcp_setopt/2 to provide further configuration if needed.