### PR TITLE
Add the ability to create Unix-domain sockets

### DIFF
--- a/socket.c
+++ b/socket.c
@@ -572,7 +572,14 @@ static foreign_t
 unix_socket(term_t socket)
 {
 #ifdef __WINDOWS__
-  return FALSE;
+  term_t except = PL_new_term_ref();
+
+  PL_unify_term(except,
+                PL_FUNCTOR_CHARS, "error", 2,
+                PL_CHARS, "system_error",
+                PL_CHARS, "unimplemented");
+
+  return PL_raise_exception(except);
 #else
  return create_socket(AF_UNIX, socket, SOCK_STREAM);
 #endif
@@ -598,7 +605,14 @@ static foreign_t
 pl_connect_unix(term_t Socket, term_t Address)
 {
 #ifdef __WINDOWS__
-  return FALSE;
+  term_t except = PL_new_term_ref();
+
+  PL_unify_term(except,
+                PL_FUNCTOR_CHARS, "error", 2,
+                PL_CHARS, "system_error",
+                PL_CHARS, "unimplemented");
+
+  return PL_raise_exception(except);
 #else
   nbio_sock_t sock;
   char* file_name_chars;

--- a/socket.c
+++ b/socket.c
@@ -568,15 +568,12 @@ udp_socket(term_t socket)
 }
 
 
+#ifndef __WINDOWS__
 static foreign_t
 unix_socket(term_t socket)
-{
-#ifdef __WINDOWS__
-  return PL_resource_error("unix_sockets");
-#else
- return create_socket(AF_UNIX, socket, SOCK_STREAM);
-#endif
+{ return create_socket(AF_UNIX, socket, SOCK_STREAM);
 }
+#endif
 
 
 static foreign_t
@@ -594,13 +591,10 @@ pl_connect(term_t Socket, term_t Address)
   return FALSE;
 }
 
+#ifndef __WINDOWS__
 static foreign_t
 pl_connect_unix(term_t Socket, term_t Address)
-{
-#ifdef __WINDOWS__
-  return PL_resource_error("unix_sockets");
-#else
-  nbio_sock_t sock;
+{ nbio_sock_t sock;
   char* file_name_chars;
 
   if ( !tcp_get_socket(Socket, &sock) ) {
@@ -622,8 +616,8 @@ pl_connect_unix(term_t Socket, term_t Address)
   }
 
   return FALSE;
-#endif
 }
+#endif
 
 static foreign_t
 pl_bind(term_t Socket, term_t Address)
@@ -761,8 +755,10 @@ install_socket(void)
   PL_register_foreign("udp_receive",	      4, udp_receive,	      0);
   PL_register_foreign("udp_send",	      4, udp_send,	      0);
 
+#ifndef __WINDOWS__
   PL_register_foreign("unix_socket",          1, unix_socket,         0);
   PL_register_foreign("unix_connect",         2, pl_connect_unix,        0);
+#endif
 
 #ifdef O_DEBUG
   PL_register_foreign("tcp_debug",	      1, pl_debug,	      0);

--- a/socket.c
+++ b/socket.c
@@ -546,7 +546,7 @@ udp_send(term_t Socket, term_t Data, term_t To, term_t Options)
 
 
 static foreign_t
-  create_socket(int domain, term_t socket, int type)
+create_socket(int domain, term_t socket, int type)
 { nbio_sock_t sock;
 
   if ( !(sock = nbio_socket(domain, type, 0)) )

--- a/socket.c
+++ b/socket.c
@@ -572,14 +572,7 @@ static foreign_t
 unix_socket(term_t socket)
 {
 #ifdef __WINDOWS__
-  term_t except = PL_new_term_ref();
-
-  PL_unify_term(except,
-                PL_FUNCTOR_CHARS, "error", 2,
-                PL_CHARS, "system_error",
-                PL_CHARS, "unimplemented");
-
-  return PL_raise_exception(except);
+  return PL_resource_error("unix_sockets");
 #else
  return create_socket(AF_UNIX, socket, SOCK_STREAM);
 #endif
@@ -605,14 +598,7 @@ static foreign_t
 pl_connect_unix(term_t Socket, term_t Address)
 {
 #ifdef __WINDOWS__
-  term_t except = PL_new_term_ref();
-
-  PL_unify_term(except,
-                PL_FUNCTOR_CHARS, "error", 2,
-                PL_CHARS, "system_error",
-                PL_CHARS, "unimplemented");
-
-  return PL_raise_exception(except);
+  return PL_resource_error("unix_sockets");
 #else
   nbio_sock_t sock;
   char* file_name_chars;

--- a/socket.pl
+++ b/socket.pl
@@ -57,6 +57,9 @@
             udp_receive/4,              % +Socket, -Data, -Sender, +Options
             udp_send/4,                 % +Socket, +Data, +Sender, +Options
 
+            unix_socket/1,              % -Socket
+            unix_connect/2,             % +Socket, +Address
+
             negotiate_socks_connection/2% +DesiredEndpoint, +StreamPair
           ]).
 :- autoload(library(debug),[debug/3]).
@@ -181,6 +184,28 @@ defined.
 
 :- use_foreign_library(foreign(socket), install_socket).
 :- public tcp_debug/1.                  % set debugging.
+
+%!  unix_socket(-SocketId) is det.
+%
+%   Creates an AF_UNIX-domain stream-socket and unifies an identifier
+%   to it with =SocketId=. On MS-Windows, this will always return false.
+
+%!  unix_connect(+SocketId, +Address) is det.
+%
+%   Connect =SocketId=. After successful completion, tcp_open_socket/3
+%   can be used to create I/O-Streams to the socket.
+%   Example usage:
+%
+%     ==
+%         unix_socket(Sock),
+%         unix_connect(Sock, "/path/to/sock"),
+%         setup_call_cleanup(
+%            tcp_open_socket(Sock, Stream),
+%            format(Stream, "hello!~n", []),
+%            close(Stream)
+%         )
+%     ==
+%
 
 %!  tcp_socket(-SocketId) is det.
 %

--- a/socket.pl
+++ b/socket.pl
@@ -182,34 +182,16 @@ defined.
 :- use_foreign_library(foreign(socket), install_socket).
 :- public tcp_debug/1.                  % set debugging.
 
-:- if(current_predicate(unix_socket/1)).
-:- export((
-                 unix_socket/1,  % -Socket
-                 unix_connect/2  % +Socket, +Address
-)).
+:- if(current_predicate(unix_domain_socket/1)).
+:- export((unix_domain_socket/1  % -Socket
+          )).
 
-%!  unix_socket(-SocketId) is det.
+%!  unix_domain_socket(-SocketId) is det.
 %
-%   Creates an AF_UNIX-domain stream-socket and unifies an identifier
-%   to it with =SocketId=. On MS-Windows, this will throw a resource error.
+%   Creates an AF_UNIX-domain stream-socket and unifies an
+%   identifier to it with =SocketId=. On MS-Windows, this predicate
+%   does not exist.
 
-%!  unix_connect(+SocketId, +Address) is det.
-%
-%   Connect =SocketId=. After successful completion, tcp_open_socket/3
-%   can be used to create I/O-Streams to the socket.
-%   Example usage:
-%
-%     ==
-%         unix_socket(Sock),
-%         unix_connect(Sock, "/path/to/sock"),
-%         setup_call_cleanup(
-%            tcp_open_socket(Sock, Stream),
-%            format(Stream, "hello!~n", []),
-%            close(Stream)
-%         )
-%     ==
-%
-%  On MS-Windows, this will throw a resource error.
 :- endif.
 
 %!  tcp_socket(-SocketId) is det.

--- a/socket.pl
+++ b/socket.pl
@@ -188,7 +188,7 @@ defined.
 %!  unix_socket(-SocketId) is det.
 %
 %   Creates an AF_UNIX-domain stream-socket and unifies an identifier
-%   to it with =SocketId=. On MS-Windows, this will throw a system error.
+%   to it with =SocketId=. On MS-Windows, this will throw a resource error.
 
 %!  unix_connect(+SocketId, +Address) is det.
 %
@@ -206,7 +206,7 @@ defined.
 %         )
 %     ==
 %
-%  On MS-Windows, this will throw a system error.
+%  On MS-Windows, this will throw a resource error.
 
 %!  tcp_socket(-SocketId) is det.
 %

--- a/socket.pl
+++ b/socket.pl
@@ -57,9 +57,6 @@
             udp_receive/4,              % +Socket, -Data, -Sender, +Options
             udp_send/4,                 % +Socket, +Data, +Sender, +Options
 
-            unix_socket/1,              % -Socket
-            unix_connect/2,             % +Socket, +Address
-
             negotiate_socks_connection/2% +DesiredEndpoint, +StreamPair
           ]).
 :- autoload(library(debug),[debug/3]).
@@ -185,6 +182,12 @@ defined.
 :- use_foreign_library(foreign(socket), install_socket).
 :- public tcp_debug/1.                  % set debugging.
 
+:- if(current_predicate(unix_socket/1)).
+:- export((
+                 unix_socket/1,  % -Socket
+                 unix_connect/2  % +Socket, +Address
+)).
+
 %!  unix_socket(-SocketId) is det.
 %
 %   Creates an AF_UNIX-domain stream-socket and unifies an identifier
@@ -207,6 +210,7 @@ defined.
 %     ==
 %
 %  On MS-Windows, this will throw a resource error.
+:- endif.
 
 %!  tcp_socket(-SocketId) is det.
 %

--- a/socket.pl
+++ b/socket.pl
@@ -188,7 +188,7 @@ defined.
 %!  unix_socket(-SocketId) is det.
 %
 %   Creates an AF_UNIX-domain stream-socket and unifies an identifier
-%   to it with =SocketId=. On MS-Windows, this will always return false.
+%   to it with =SocketId=. On MS-Windows, this will throw a system error.
 
 %!  unix_connect(+SocketId, +Address) is det.
 %
@@ -206,6 +206,7 @@ defined.
 %         )
 %     ==
 %
+%  On MS-Windows, this will throw a system error.
 
 %!  tcp_socket(-SocketId) is det.
 %


### PR DESCRIPTION
As mentioned on [the Discourse](https://swi-prolog.discourse.group/t/unix-sockets-with-swi/2123/4).

This seems to be working for me now, although I'm not sure why the pldoc comments aren't showing up.

Tested by starting a socket with `nc -lU /tmp/foo.sock` in a terminal, then running

```prolog
?-  unix_socket(Sock),
     unix_connect(Sock, "/tmp/foo.sock"),
     setup_call_cleanup(
         tcp_open_socket(Sock, Stream),
         format(Stream, "hello!~n", []),
          close(Stream)
       ).
```