### PR TITLE
Handle EISCONN under non-windows systems too.

### DIFF
--- a/nonblockio.c
+++ b/nonblockio.c
@@ -1236,6 +1236,9 @@ nbio_connect(nbio_sock_t socket,
 #ifdef __WINDOWS__
       if ( GET_ERRNO == WSAEISCONN )
         break;
+#else
+      if ( GET_ERRNO == EISCONN )
+        break;
 #endif
       nbio_error(GET_ERRNO, TCP_ERRNO);
       return -1;


### PR DESCRIPTION
I've traced this to be the cause of https://github.com/SWI-Prolog/swipl-devel/issues/607

This happens when we retry to connect due to interrupt/signal but we actually already have established an connection and can safely return here. I think until now this was only handled under Windows, the patch should enable it on other systems too.
