### PR TITLE
FIXED: cut redundant choice point

### DIFF
--- a/udp_broadcast.pl
+++ b/udp_broadcast.pl
@@ -522,6 +522,7 @@ ld_dispatch(S, request(Key, Term), From, Scope) :-
            safely((udp_term_string(Scope, reply(Key,Term), Message),
                    udp_send(S, Message, From, [])))).
 ld_dispatch(_S, send(Term), _From, _Scope) :-
+    !,
     safely_det(broadcast(Term)).
 ld_dispatch(_S, reply(Key, Term), From, _Scope) :-
     (   reply_queue(Key, Queue)


### PR DESCRIPTION
Fills up the inbound proxy's call stack with redundant choice points _without_ the cut. The call stack eventually overflows.