### PR TITLE
Add SICStus-compatible pipe(Stream, Options) support to process_create/3

### DIFF
--- a/process.pl
+++ b/process.pl
@@ -95,10 +95,6 @@ following finds the executable for =ls=:
     distinction. This implies that is_process/1 is incomplete and
     unreliable.
 
-    * SICStus only supports ISO 8859-1 (latin-1). This implementation
-    supports arbitrary OS multibyte interaction using the default
-    locale.
-
     * It is unclear what the detached(true) option is supposed to do. Disable
     signals in the child? Use setsid() to detach from the session?  The
     current implementation uses setsid() on Unix systems.

--- a/process.pl
+++ b/process.pl
@@ -132,7 +132,9 @@ following finds the executable for =ls=:
 %       Bind the standard streams of the new process. Spec is one of
 %       the terms below. If pipe(Pipe) is used, the Prolog stream is
 %       a stream in text-mode using the encoding of the default
-%       locale.  The encoding can be changed using set_stream/2.
+%       locale.  The encoding can be changed using set_stream/2,
+%       or by using the two-argument form of =pipe=, which accepts an
+%       encoding(Encoding) option.
 %       The options =stdout= and =stderr= may use the same stream,
 %       in which case both output streams are connected to the same
 %       Prolog stream.
@@ -146,7 +148,16 @@ following finds the executable for =ls=:
 %           Bind to a _null_ stream. Reading from such a stream
 %           returns end-of-file, writing produces no output
 %           * pipe(-Stream)
+%           * pipe(-Stream, +StreamOptions)
 %           Attach input and/or output to a Prolog stream.
+%           The optional StreamOptions argument is a list of options
+%           that affect the stream. Currently only the options
+%           type(+Type) and encoding(+Encoding) are supported,
+%           which have the same meaning as the stream properties
+%           of the same name (see stream_property/2).
+%           StreamOptions is provided mainly for SICStus compatibility -
+%           the SWI-Prolog predicate set_stream/2 can be used
+%           for the same purpose.
 %           * stream(+Stream)
 %           Attach input or output to an existing Prolog stream.
 %           This stream must be associated with an OS file
@@ -264,7 +275,11 @@ process_create(Exe, Args, Options) :-
     expand_cwd_option(Options, Options1),
     expand_env_option(env, Options1, Options2),
     expand_env_option(environment, Options2, Options3),
-    process_create(Term, Options3).
+    extract_pipe_properties(stdin, Options3, Options4, [], Pipes1),
+    extract_pipe_properties(stdout, Options4, Options5, Pipes1, Pipes2),
+    extract_pipe_properties(stderr, Options5, Options6, Pipes2, Pipes),
+    process_create(Term, Options6),
+    apply_pipe_properties(Pipes).
 
 exe_options(Options) :-
     current_prolog_flag(windows, true),
@@ -323,6 +338,33 @@ map_arg_prim(file(Spec), File) :-
     ),
     prolog_to_os_filename(PlFile, File).
 map_arg_prim(Arg, Arg).
+
+% In all options with functor Name, replace a pipe(Stream, Options)
+% argument with just pipe(Stream) and collect the original
+% pipe/2 terms in Pipes.
+extract_pipe_properties(Name, Options0, Options, Pipes0, Pipes) :-
+    Pipe = pipe(Stream, Properties),
+    Term =.. [Name, Pipe],
+    select_option(Term, Options0, Options1),
+    !,
+    must_be(list, Properties),
+    maplist(pipe_property, Properties),
+    NewOption =.. [Name, pipe(Stream)],
+    Options = [NewOption|Options1],
+    Pipes = [Pipe|Pipes0].
+extract_pipe_properties(_, Options, Options, Pipes, Pipes).
+
+pipe_property(type(binary)).
+pipe_property(type(text)).
+pipe_property(encoding(Encoding)) :- atom(Encoding).
+
+% Apply the options from a list of pipe(Stream, Options) terms
+% (as output by extract_pipe_properties/5)
+% to the corresponding streams (using set_stream/2).
+apply_pipe_properties([]).
+apply_pipe_properties([pipe(Stream, Properties)|PipesWithPropertiesTail]) :-
+    maplist(set_stream(Stream), Properties),
+    apply_pipe_properties(PipesWithPropertiesTail).
 
 
 %!  process_id(-PID) is det.


### PR DESCRIPTION
As of SICStus 4.3.2, `process_create/3`'s `stdin`/`stdout`/`stderr` options support a 2-argument form of `pipe`, which can be used to control the streams' encodings, e. g. `process_create(path(ls), [], [stdout(pipe(Stream, [type(text), encoding(utf8)]))])`. On SWI it was already possible to change the pipe stream encodings afterwards using `set_stream/2`, but that predicate is not supported on SICStus. This PR adds support for the SICStus `pipe(Stream, Options)` syntax, so that there's an easy way to set the pipe stream encodings that works on both SICStus and SWI.

This could alternatively also implemented as part of `expects_dialect(sicstus4)`. But considering that SWI's `library(process)` is meant to be SICStus-compatible, I think it makes more sense to support this feature natively.