### PR TITLE
Fix a few small errors in process_create/3 pipe option parsing

### DIFF
--- a/process.c
+++ b/process.c
@@ -399,6 +399,8 @@ get_type(term_t head, IOENC *enc)
       *enc = ENC_OCTET;
     else
       return PL_domain_error("stream_type", head);
+
+    return TRUE;
   }
 
   return FALSE;
@@ -418,9 +420,7 @@ get_encoding(term_t head, IOENC *enc)
     else if ( a == ATOM_ascii )
       *enc = ENC_ASCII;
     else if ( a == ATOM_iso_latin_1 )
-      *enc = ENC_ASCII;
-    else if ( a == ENC_ISO_LATIN_1 )
-      *enc = ENC_ASCII;
+      *enc = ENC_ISO_LATIN_1;
     else if ( a == ATOM_text )
       *enc = ENC_ANSI;
     else if ( a == ATOM_utf8 )
@@ -431,6 +431,8 @@ get_encoding(term_t head, IOENC *enc)
       *enc = ENC_UNICODE_LE;
     else
       return PL_domain_error("encoding", head);
+
+    return TRUE;
   }
 
   return FALSE;


### PR DESCRIPTION
Small fixes to 5595c0a6efea9d9fba488a291bc409f7a6503820/#34. With this change, the new options are now accepted (previously the call failed silently if a non-empty option list was passed to `pipe`).

Though it seems the options are still not applied correctly - at least on macOS, no matter what values I use for `text` and `encoding`, the pipe stream always ends up with `type(text)` and `encoding(utf8)` (which is the locale default encoding on macOS). For example:

```prolog
?- process_create(path(pbpaste), [], [process(Process), stdout(pipe(Stdout, [encoding(octet)]))]),
   stream_property(Stdout, type(Type)),
   stream_property(Stdout, encoding(Encoding)),
   read_line_to_codes(Stdout, Line),
   process_wait(Process, Exit),
   close(Stdout).
Process = 90785,
Stdout = <stream>(0x11166f300),
Type = text,
Encoding = utf8,
Line = [246],
Exit = exit(0).
```

`pbpaste` is a macOS command line tool that simply prints the contents of the clipboard, and I had the letter "ö" copied, which is number 246 in Unicode. If the `octet` encoding was applied correctly, it should have read `[195, 182]`, which is the letter "ö" encoded as UTF-8.