### PR TITLE
Fix process_create encoding option unconditionally setting UTF-16-LE

### DIFF
--- a/process.c
+++ b/process.c
@@ -418,7 +418,7 @@ get_encoding(term_t head, IOENC *enc)
   { IOENC e;
 
     if ( (e=PL_atom_to_encoding(a)) != ENC_UNKNOWN )
-    { *enc = ENC_UNICODE_LE;
+    { *enc = e;
       return TRUE;
     }
 


### PR DESCRIPTION
Bug introduced in ee1ac95dc5fb8182325297541fa19d7597f24010, breaks code that explicitly sets a process stream encoding to anything other than `unicode_le`.