### PR TITLE
If tcp_host_to_address/2 raises an exception or fails, just use the P…

### DIFF
--- a/prolog_server.pl
+++ b/prolog_server.pl
@@ -101,7 +101,10 @@ server_loop(ServerSocket, Options) :-
     tcp_open_socket(Slave, InStream, OutStream),
     set_stream(InStream, close_on_abort(false)),
     set_stream(OutStream, close_on_abort(false)),
-    tcp_host_to_address(Host, Peer),
+    (   catch(tcp_host_to_address(Host, Peer), _, fail)
+    ->  true
+    ;   term_to_atom(Peer, Host)
+    ),
     (   Postfix = []
     ;   between(2, 1000, Num),
         Postfix = [-, Num]


### PR DESCRIPTION
…eer in the thread alias, rather than having the server thread die