### PR TITLE
FIXED: directory_member/3: respect file_type(regular) option

### DIFF
--- a/filesex.pl
+++ b/filesex.pl
@@ -367,6 +367,9 @@ filter_dir_member(_, _, _).
 matches_type(directory, Entry) :-
     !,
     exists_directory(Entry).
+matches_type(regular, Entry) :-
+    !,
+    exists_file(Entry).
 matches_type(Type, Entry) :-
     \+ exists_directory(Entry),
     user:prolog_file_type(Ext, Type),


### PR DESCRIPTION
This allows `directory_member/3` to generate regular (non-directory) files with option `file_type(regular)`, in accordance with how `absolute_file_name/3` treats this option.