### PR TITLE
Add (non standard) accessor macro s6_addr16 where needed

### DIFF
--- a/nonblockio.h
+++ b/nonblockio.h
@@ -82,6 +82,12 @@ typedef int SOCKET;
 
 #endif /*__WINDOWS__*/
 
+#ifndef s6_addr16
+#ifdef __NetBSD__
+#define	s6_addr16	__u6_addr.__u6_addr16
+#endif
+#endif
+
 typedef enum
 { TCP_ERRNO,
   TCP_HERRNO,


### PR DESCRIPTION
On platforms that do not provide this out of the box, provide the  inet6 addresses accessor macro s6_addr16.

This is needed e.g. on NetBSD (and I #ifdef'd the change to that). I am not sure how this could be done better with more cmake/configury magic, open to suggestions.