### PR TITLE
FIXED: list regular files

### DIFF
--- a/filesex.pl
+++ b/filesex.pl
@@ -377,6 +377,9 @@ filter_dir_member(_, _, _).
 matches_type(directory, Entry) :-
     !,
     exists_directory(Entry).
+matches_type(regular, Entry) :-
+    !,
+    exists_file(Entry).
 matches_type(Type, Entry) :-
     \+ exists_directory(Entry),
     user:prolog_file_type(Ext, Type),


### PR DESCRIPTION
It seems to have been an oversight. Without the fix, using the option `file_type(regular)` causes `directory_member/2` to return nothing at all even when there are regular files.