### PR TITLE
Fix ssize_t undeclared identifier error on Windows MSVC

### DIFF
--- a/form.c
+++ b/form.c
@@ -49,6 +49,8 @@
 #include "form.h"
 #ifdef __WINDOWS__
 #include <io.h>
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
 #define read _read
 #define fileno _fileno
 #endif


### PR DESCRIPTION
## Problem

On Windows MSVC builds, `ssize_t` is not defined in standard headers, causing compilation to fail with:

error C2065: 'ssize_t': undeclared identifier

This occurs at line 366 in `form.c` where the variable `done` stores the return value from `read()`, which returns `ssize_t` (a signed type needed for negative error values).

## Solution

Added Windows-specific typedef using `SSIZE_T` from `<BaseTsd.h>`, following the same pattern used in other SWI-Prolog packages (`libedit`, `utf8proc`).

## Changes

- Added `#include <BaseTsd.h>` in the `#ifdef __WINDOWS__` block
- Added `typedef SSIZE_T ssize_t;` for Windows builds

## Testing

- Built successfully with MSVC on Windows
- The `ssize_t` type is correctly defined and allows proper error checking from `read()` return values

## Note

This supersedes PR #64, which incorrectly proposed changing `ssize_t` to `size_t`. That approach would break error handling since `size_t` is unsigned and cannot represent the negative error values returned by `read()`.