### PR TITLE
Fix missing semicolon in ssize_t typedef for MSVC

### DIFF
--- a/form.c
+++ b/form.c
@@ -49,11 +49,11 @@
 #include "form.h"
 #ifdef __WINDOWS__
 #include <io.h>
+#ifdef _MSC_VER
+typedef intptr_t ssize_t;
+#endif
 #define read _read
 #define fileno _fileno
-#ifdef _MSC_VER
-typedef intptr_t ssize_t
-#endif
 #endif
 
 #include "error.h"


### PR DESCRIPTION
## Problem

Commit 9c474fa added `ssize_t` typedef for MSVC but was missing a semicolon on line 55, causing compilation errors:

error C2054: expected '(' to follow 'ssize_t'



## Solution

- Added missing semicolon: `typedef intptr_t ssize_t;`
- Reordered typedef to come before `#define` macros to match SWI-Prolog convention (see `src/os/windows/uxnt.h` and `src/os/SWI-Stream.h`)

## Testing

- Built successfully with MSVC on Windows
- All clib tests pass
- Follows the same pattern used throughout SWI-Prolog codebase

## Related

This fixes the syntax error in commit 9c474fa and complements PR #65.