### PR TITLE
Fix MSVC C4018 warning: signed/unsigned mismatch in nbio_write()

### DIFF
--- a/nonblockio.c
+++ b/nonblockio.c
@@ -1524,7 +1524,7 @@ nbio_write(nbio_sock_t socket, char *buf, size_t bufSize)
       nbio_error(GET_ERRNO, TCP_ERRNO);
       return -1;
     }
-    if ( n < len )
+    if ( (size_t)n < len )
     { if ( PL_handle_signals() < 0 )
       { errno = EPLEXCEPTION;
         return -1;


### PR DESCRIPTION
## Summary

Fix MSVC C4018 warning about signed/unsigned comparison in `nonblockio.c`.

### Changes

- **Line 1527**: Cast `n` (`ssize_t`) to `(size_t)` before comparing with `len` (`size_t`) in the expression `if ( n < len )`

### Safety

The cast is safe because `n` is guaranteed non-negative at this point — the `n < 0` error path was already handled at line 1512 and would have either returned or continued.

### Testing

Built and tested with MSVC (Visual Studio 2026) on Windows x64. Warning is resolved.